### PR TITLE
Support program runtime config file

### DIFF
--- a/launcher/Cargo.toml
+++ b/launcher/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 
 [dependencies]
 which = { version = "4.2.5" }
+yaml-rust = { version = "0.4" }

--- a/launcher/src/app_path.rs
+++ b/launcher/src/app_path.rs
@@ -1,6 +1,11 @@
+extern crate yaml_rust;
+
 use std::env;
 use which::which;
 use std::path::Path;
+use std::fs;
+use yaml_rust::Yaml;
+use yaml_rust::YamlLoader;
 
 pub fn program_abs_path() -> String {
     /*!
@@ -22,4 +27,23 @@ pub fn basename(program_path: &String) -> String {
         Path::new(program_path).file_name().unwrap().to_str().unwrap()
     );
     program_name
+}
+
+pub fn program_config_file(program_basename: &String) -> String {
+    /*!
+    Provide expected config file path for the given program_basename
+    !*/
+    let config_file = &format!("/etc/pilot/{}.yaml", program_basename);
+    config_file.to_string()
+}
+
+pub fn program_config(program_basename: &String) -> Vec<Yaml> {
+    /*!
+    Read container runtime configuration for given program
+    !*/
+    let config_file = program_config_file(program_basename);
+    let yaml_content = fs::read_to_string(&config_file)
+        .expect(&format!("Failed to read program config {}", config_file));
+    let yaml = YamlLoader::load_from_str(&yaml_content).unwrap();
+    yaml
 }

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1,9 +1,9 @@
+#[cfg(test)]
+pub mod tests;
+
 pub mod app_path;
 pub mod container_link;
 pub mod podman;
-
-#[cfg(test)]
-pub mod tests;
 
 fn main() {
     let program_path = app_path::program_abs_path();

--- a/launcher/src/podman.rs
+++ b/launcher/src/podman.rs
@@ -1,13 +1,23 @@
 use std::process::Command;
 use std::process::exit;
+use std::path::Path;
 use std::env;
+use crate::app_path::program_config;
+use crate::app_path::program_config_file;
 
 pub fn run(program_name: &String, container_name: &String) {
     /*!
     Call podman run and execute program_name inside of container_name
-    All commandline options which does not start with the @ magic
-    indicator for pilot options will be passed to the program_name
-    called in the container.
+    All commandline options will be passed to the program_name
+    called in the container. Options to control how podman starts
+    the container can be provided as /etc/pilot/program_name.yaml
+    like the following example shows:
+
+    runtime:
+      --storage-opt: size=10G
+      --rm:
+
+    If no runtime configuration exists the following defaults apply
 
     - Container resources will be automatically deleted after the call.
     - Interactive sessions will be allowed
@@ -17,18 +27,28 @@ pub fn run(program_name: &String, container_name: &String) {
     obtained
     !*/
     let args: Vec<String> = env::args().collect();
+
     let mut app = Command::new("podman");
 
-    app.arg("run")
-        .arg("--rm")
-        .arg("-ti")
-        .arg(container_name)
-        .arg(program_name);
-
-    for arg in &args[1..] {
-        if ! arg.starts_with("@") {
-            app.arg(arg);
+    // setup podman runtime arguments
+    app.arg("run");
+    if Path::new(&program_config_file(&program_name)).exists() {
+        let runtime_config = program_config(&program_name);
+        let runtime_section = &runtime_config[0]["runtime"];
+        for (opt, opt_value) in runtime_section.as_hash().unwrap() {
+            app.arg(opt.as_str().unwrap());
+            if ! opt_value.as_str().is_none() {
+                app.arg(opt_value.as_str().unwrap());
+            }
         }
+    } else {
+        app.arg("--rm").arg("-ti");
+    }
+    app.arg(container_name).arg(program_name);
+
+    // setup program arguments
+    for arg in &args[1..] {
+        app.arg(arg);
     }
 
     let status = app.status()

--- a/launcher/src/tests.rs
+++ b/launcher/src/tests.rs
@@ -2,12 +2,19 @@ use which::which;
 use std::env;
 use crate::app_path::program_abs_path;
 use crate::app_path::basename;
+use crate::app_path::program_config_file;
 use crate::container_link::container_name;
 
 #[test]
 fn test_program_abs_path() {
     let program_path = program_abs_path();
     assert!(program_path.starts_with("/"));
+}
+
+#[test]
+fn test_program_config_file() {
+    let config_file = program_config_file(&format!("app"));
+    assert_eq!("/etc/pilot/app.yaml", config_file);
 }
 
 #[test]


### PR DESCRIPTION
Options to control how podman starts the container can now be
provided as ```/etc/pilot/program_name.yaml``` like the following
example shows:

```yaml
runtime:
  --storage-opt: size=10G
  --rm:
```

If no runtime configuration exists the following defaults apply

* Container resources will be automatically deleted after the call.
* Interactive sessions will be allowed